### PR TITLE
fix: fix typo on instruction link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you are looking to dig deeper into ZMK and develop new functionality, it is r
  
 ## Instructions
 1. Log into, or sign up for, your personal GitHub account.
-2. Create your own repository using this repository as a template ([instructions](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template])) and check it out on your local computer.
+2. Create your own repository using this repository as a template ([instructions](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template)) and check it out on your local computer.
 3. Edit the keymap file(s) to suit your needs
 4. Commit and push your changes to your personal repo. Upon pushing it, GitHub Actions will start building a new version of your firmware with the updated keymap.
 


### PR DESCRIPTION
There was a typo on the instruction link, leading to a 404
![image](https://github.com/MoonKraken/glove80-zmk-config/assets/93339170/4cf3e8ae-25d8-4821-9f16-0f5dd5105d1d)

This pr removes the extra closing square bracket ']' to redirect to the correct resource.